### PR TITLE
Parse timestamps using timezone

### DIFF
--- a/databricks.go
+++ b/databricks.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"io"
 	"io/ioutil"
+	"time"
 )
 
 func init() {
@@ -18,8 +19,19 @@ type Options struct {
 	HTTPPath string
 	MaxRows  int64
 	Timeout  int
+	Loc      *time.Location
 
 	LogOut io.Writer
+}
+
+func (o *Options) Equal(o2 *Options) bool {
+	return o.Host == o2.Host &&
+		o.Port == o2.Port &&
+		o.Token == o2.Token &&
+		o.HTTPPath == o2.HTTPPath &&
+		o.MaxRows == o2.MaxRows &&
+		o.Timeout == o2.Timeout &&
+		o.Loc.String() == o2.Loc.String()
 }
 
 var (

--- a/driver.go
+++ b/driver.go
@@ -32,7 +32,8 @@ func (d *Driver) Open(uri string) (driver.Conn, error) {
 		return nil, err
 	}
 
-	log.Printf("opts: %v", opts)
+	// (eric) Don't log opts because it contains sensitive information.
+	// log.Printf("opts: %v", opts)
 
 	conn, err := connect(opts)
 	if err != nil {
@@ -101,6 +102,13 @@ func parseURI(uri string) (*Options, error) {
 		}
 	}
 
+	opts.Loc = time.UTC
+	if tz, ok := query["tz"]; ok {
+		if loc, err := time.LoadLocation(tz[0]); err == nil {
+			opts.Loc = loc
+		}
+	}
+
 	return &opts, nil
 }
 
@@ -166,7 +174,7 @@ func connect(opts *Options) (*Conn, error) {
 	protocolFactory := thrift.NewTBinaryProtocolFactoryDefault()
 	tclient := thrift.NewTStandardClient(protocolFactory.GetProtocol(transport), protocolFactory.GetProtocol(transport))
 
-	client := hive.NewClient(tclient, logger, &hive.Options{MaxRows: opts.MaxRows})
+	client := hive.NewClient(tclient, logger, &hive.Options{MaxRows: opts.MaxRows, Loc: opts.Loc})
 
 	return &Conn{client: client, t: transport, log: logger}, nil
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -3,32 +3,42 @@ package dbsql
 import (
 	"io/ioutil"
 	"testing"
+	"time"
 )
 
 func TestParseURI(t *testing.T) {
+	americaLosAngelesTz, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		in  string
 		out Options
 	}{
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 10000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 10000, Timeout: 0, LogOut: ioutil.Discard, Loc: time.UTC},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 10000, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 10000, LogOut: ioutil.Discard, Loc: time.UTC},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123&maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard, Loc: time.UTC},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard, Loc: time.UTC},
 		},
 		{
 			"databricks://:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard, Loc: time.UTC},
+		},
+		{
+			"databricks://:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000&tz=America%2FLos_Angeles",
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard, Loc: americaLosAngelesTz},
 		},
 	}
 
@@ -39,7 +49,7 @@ func TestParseURI(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			if *opts != tt.out {
+			if !opts.Equal(&tt.out) {
 				t.Errorf("got: %v, want: %v", opts, tt.out)
 			}
 		})

--- a/hive/client.go
+++ b/hive/client.go
@@ -3,6 +3,7 @@ package hive
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/databricks/databricks-sql-go/cli_service"
@@ -18,6 +19,7 @@ type Client struct {
 // Options for Hive Client
 type Options struct {
 	MaxRows int64
+	Loc     *time.Location
 }
 
 // NewClient creates Hive Client

--- a/hive/operation.go
+++ b/hive/operation.go
@@ -74,6 +74,7 @@ func (op *Operation) FetchResults(ctx context.Context, schema *TableSchema) (*Re
 		result:  resp.Results,
 		more:    resp.GetHasMoreRows(),
 		schema:  schema,
+		loc:     op.hive.opts.Loc,
 		fetchfn: func() (*cli_service.TFetchResultsResp, error) { return fetch(ctx, op, schema) },
 	}
 


### PR DESCRIPTION
1. Adds a `tz` option to the DSN
2. Passes it down to the place where we parse the timestamp that the Thrift server returns

Note that this PR doesn't change the session timezone on the server side; users of this driver will still need to manually issue a `SET TIME ZONE` statement in addition to setting the `tz` option.