### PR TITLE
Fix: FetchResults truncates rows returned by the server

### DIFF
--- a/hive/result_set.go
+++ b/hive/result_set.go
@@ -23,19 +23,26 @@ type ResultSet struct {
 
 // Next ...
 func (rs *ResultSet) Next(dest []driver.Value) error {
-	if rs.idx >= rs.length {
-		if !rs.more {
-			return io.EOF
-		}
 
+	var thisPageExhausted bool = rs.idx >= length(rs.result)
+
+	if thisPageExhausted {
+
+		// Fetch another page
 		resp, err := rs.fetchfn()
+
 		if err != nil {
 			return err
 		}
+
+		// Replace previous page of results with new page of results
 		rs.result = resp.Results
-		rs.more = resp.GetHasMoreRows()
-		rs.idx = 0
+
+		// Replace previous page length with new page length
 		rs.length = length(rs.result)
+
+		// Reset index to the start of the new page
+		rs.idx = 0
 	}
 
 	if rs.length == 0 {
@@ -47,8 +54,10 @@ func (rs *ResultSet) Next(dest []driver.Value) error {
 		if err != nil {
 			return err
 		}
+
 		dest[i] = val
 	}
+
 	rs.idx++
 	return nil
 }


### PR DESCRIPTION
Patching in Jesse's workaround to fetch all pages of a query result.

Apache Hive thrift always sends HasMoreResults==false

This change updates the Next() method to continuing fetching pages of
results until an empty page is received.

Signed-off-by: Jesse Whitehouse <jesse@whitehouse.dev>