### PR TITLE
Add logging for uses of each connection

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -109,6 +111,16 @@ func parseURI(uri string) (*Options, error) {
 		}
 	}
 
+	if logOut, ok := query["logOut"]; ok {
+		if logOut[0] == "stdout" {
+			opts.LogOut = os.Stdout
+		} else if logOut[0] == "stderr" {
+			opts.LogOut = os.Stderr
+		} else {
+			return nil, fmt.Errorf("invalid logOut %s", logOut[0])
+		}
+	}
+
 	return &opts, nil
 }
 
@@ -176,5 +188,8 @@ func connect(opts *Options) (*Conn, error) {
 
 	client := hive.NewClient(tclient, logger, &hive.Options{MaxRows: opts.MaxRows, Loc: opts.Loc})
 
-	return &Conn{client: client, t: transport, log: logger}, nil
+	connId := rand.Uint64()
+
+	logger.Printf("connect: connId=%d host=%s port=%s httpPath=%s", connId, opts.Host, opts.Port, opts.HTTPPath)
+	return &Conn{client: client, t: transport, log: logger, id: connId}, nil
 }

--- a/hive/operation.go
+++ b/hive/operation.go
@@ -52,9 +52,9 @@ func (op *Operation) GetResultSetMetadata(ctx context.Context) (*TableSchema, er
 			})
 		}
 
-		for _, col := range schema.Columns {
-			op.hive.log.Printf("fetch schema: %v", col)
-		}
+		//for _, col := range schema.Columns {
+		//	op.hive.log.Printf("fetch schema: %v", col)
+		//}
 	}
 
 	return schema, nil
@@ -99,7 +99,7 @@ func fetch(ctx context.Context, op *Operation, schema *TableSchema) (*cli_servic
 		return nil, WithStack(err)
 	}
 
-	op.hive.log.Printf("results: %v", resp.Results)
+	//op.hive.log.Printf("results: %v", resp.Results)
 	return resp, nil
 }
 


### PR DESCRIPTION
To investigate [SIG-25846] and detect potential race conditions, this PR makes the following changes:

1. Attach a randomly generated ID to each instance of `Conn` that we create
2. Add log statements to each operation on Conn containing the operation name, driver connection ID, and a stack trace for the current goroutine.
3. Remove several log statements that are either noisy or otherwise undesirable. (The logging library used here doesn't support log levels 😭)
4. Add an option for clients to enable logging if they want to.