### PR TITLE
Remove newline from op log

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -24,7 +24,7 @@ type Conn struct {
 }
 
 func (c *Conn) logOp(op string) {
-	c.log.Printf("%s: connId=%d\n%s", op, c.id, debug.Stack())
+	c.log.Printf("%s: connId=%d %s", op, c.id, debug.Stack())
 }
 
 func (c *Conn) Ping(ctx context.Context) error {


### PR DESCRIPTION
The first line of the stack trace contains the goroutine ID, which looks like `goroutine 16557 [running]:`. It seems helpful to put this on the same line as the operation name and driver connection ID, to make it easier to parse/search the logs.