### PR TITLE
Rebase fork with upstream 2022-09-30

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, these
+# users will be requested for review when someone opens a
+# pull request.
+*       @arikfr @susodapop @moderakh @yunbodeng-db

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,0 +1,25 @@
+name: DCO Check
+
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for DCO
+        id: dco-check
+        uses: tisonkun/actions-dco@v1.1
+      - name: Comment about DCO status
+        uses: actions/github-script@v6
+        if: ${{ failure() }}
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Thanks for your contribution! To satisfy the DCO policy in our \
+              [contributing guide](https://github.com/databricks/databricks-sql-go/blob/main/CONTRIBUTING.md) \
+              every commit message must include a sign-off message. One or more of your commits is missing this message. \
+              You can reword previous commit messages with an interactive rebase (\`git rebase -i main\`).`
+            })

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Release History
+
+## 0.1.x (Unreleased)
+
+
+## 0.1.3 (2022-06-16)
+
+- Add escaping of string parameters.
+
+## 0.1.2 (2022-06-10)
+
+- Fix timeout units to be milliseconds instead of nanos.
+
+## 0.1.1 (2022-05-19)
+
+- Fix module name
+
+## 0.1.0 (2022-05-19)
+
+- Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.1.x (Unreleased)
 
+## 0.1.4 (2022-07-30)
+
+- Fix: Could not fetch rowsets greater than the value of `maxRows` (#18)
+- Updated default user agent
+- Updated README and CONTRIBUTING
 
 ## 0.1.3 (2022-06-16)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,72 @@
-# Contributing
+# Contributing Guide
 
-To contribute to this repository, fork it and send pull requests.
+We happily welcome contributions to this package. We use [GitHub Issues](https://github.com/databricks/databricks-sql-go/issues) to track community reported issues and [GitHub Pull Requests](https://github.com/databricks/databricks-sql-go/pulls) for accepting changes.
+
+Contributions are licensed on a license-in/license-out basis.
+
+## Communication
+
+Before starting work on a major feature, please reach out to us via GitHub, Slack, email, etc. We will make sure no one else is already working on it and ask you to open a GitHub issue.
+A "major feature" is defined as any change that is > 100 LOC altered (not including tests), or changes any user-facing behavior.
+We will use the GitHub issue to discuss the feature and come to agreement.
+This is to prevent your time being wasted, as well as ours.
+The GitHub review process for major features is also important so that organizations with commit access can come to agreement on design.
+If it is appropriate to write a design document, the document must be hosted either in the GitHub tracking issue, or linked to from the issue and hosted in a world-readable location.
+Specifically, if the goal is to add a new extension, please read the extension policy.
+Small patches and bug fixes don't need prior communication.
+
+## Sign your work
+
+The sign-off is a simple line at the end of the explanation for the patch. Your signature certifies that you wrote the patch or otherwise have the right to pass it on as an open-source patch. The rules are pretty simple: if you can certify the below (from developercertificate.org):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+```
+Signed-off-by: Joe Smith <joe.smith@email.com>
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+```
+
+If you set your `user.name` and `user.email` git configs, you can sign your commit automatically with `git commit -s`.
 
 ## Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+To contribute to this repository, fork it and send pull requests.
+
+## Pull Request Process
+
+1. Update the [CHANGELOG](CHANGELOG.md) with details of your changes, if applicable.
+2. Add any appropriate tests.
+3. Make your code or other changes.
+4. Review guidelines such as
+   [How to write the perfect pull request][github-perfect-pr], thanks!
+
+[github-perfect-pr]: https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,35 @@
+Databricks SQL Driver for Go
+
+Copyright (2022) Databricks, Inc.
+
+This Software includes software developed at Databricks (https://www.databricks.com/) and its use is subject to the included LICENSE file.
+
+Additionally, this Software contains code from the following open source projects:
+
+- go-impala version 2.1.0
+
+
+go-impala NOTICES AND INFORMATION BEGIN HERE
+==============================================
+
+The MIT License (MIT)
+
+Copyright (c) 2015 David Koblas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The DSN format is:
 databricks://:[your token]@[Workspace hostname][Endpoint HTTP Path]
 ```
 
-You can set HTTP Timeout value by appending a `timeout` query parameter (in milliseconds) and you can set max rows to retrieve by setting the `maxRows` query parameter:
+You can set HTTP Timeout value by appending a `timeout` query parameter (in milliseconds) and you can set max rows to retrieve per network request by setting the `maxRows` query parameter:
 
 ```
 databricks://:[your token]@[Workspace hostname][Endpoint HTTP Path]?timeout=1000&maxRows=1000

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import (
 	_ "github.com/databricks/databricks-sql-go"
 )
 
-db, err := sql.Open("databricks", "databricks://:dapi-secret-token@example.cloud.databricks.com/sql/1.0/endpoints/12345a1b2c3d456f")
+db, err := sql.Open("databricks", "databricks://:dapi********@********.databricks.com/sql/1.0/endpoints/********")
 if err != nil {
 	panic(err)
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
-# Go Databricks SQL Driver (Beta)
+# Databricks SQL Driver for Go (Beta)
 
-Databricks SQL driver for Go's [database/sql](https://golang.org/pkg/database/sql) package.
+
+![http://www.apache.org/licenses/LICENSE-2.0.txt](http://img.shields.io/:license-Apache%202-brightgreen.svg)
+
+## Description
+
+This repo contains a Databricks SQL Driver for Go's [database/sql](https://golang.org/pkg/database/sql) package. It can be used to connect and query Databricks clusters and SQL Warehouses. This project is a fork of [go-impala](https://github.com/bippio/go-impala).
 
 **NOTE: This Driver is Beta.**
+
+## Documentation
+
+Full documentation is not yet available. See below for usage examples.
 
 ## Usage
 
@@ -23,11 +32,11 @@ if err != nil {
 rows, err := db.Query("SELECT 1")
 ```
 
-(see additional usage examples in [examples](https://github.com/databricks/databricks-sql-go/tree/main/examples))
+Additional usage examples are available [here](https://github.com/databricks/databricks-sql-go/tree/main/examples).
 
-## DSN (Data Source Name)
+### DSN (Data Source Name)
 
-The Data Source Name expected is of the following format:
+The DSN format is:
 
 ```
 databricks://:[your token]@[Workspace hostname][Endpoint HTTP Path]
@@ -41,12 +50,28 @@ databricks://:[your token]@[Workspace hostname][Endpoint HTTP Path]?timeout=1000
 
 ## Testing
 
-To run only unit tests you can use `go test`, but if you want to run tests against a SQL warehouse, you will need to pass a DSN environment variable:
+### Unit Tests
+
+```bash
+go test
+```
+
+### e2e Tests
+
+To run tests against a SQL warehouse, you need to pass a DSN environment variable first:
 
 ```
 $ DATABRICKS_DSN="databricks://:dapi-secret-token@example.cloud.databricks.com/sql/1.0/endpoints/12345a1b2c3d456f" go test
 ```
 
+## Issues
+
+If you find any issues, feel free to create an issue or send a pull request directly.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md)
+
 ## License
 
-Apache 2.0.
+[Apache 2.0](https://github.com/databricks/databricks-sql-nodejs/blob/master/LICENSE)

--- a/connection.go
+++ b/connection.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"log"
+	"runtime/debug"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -17,9 +18,18 @@ type Conn struct {
 	session *hive.Session
 	client  *hive.Client
 	log     *log.Logger
+
+	// Randomly-generated unique ID used to refer to this Conn.
+	id uint64
+}
+
+func (c *Conn) logOp(op string) {
+	c.log.Printf("%s: connId=%d %s", op, c.id, debug.Stack())
 }
 
 func (c *Conn) Ping(ctx context.Context) error {
+	c.logOp("Ping")
+
 	session, err := c.OpenSession(ctx)
 	if err != nil {
 		return hive.WithStack(err)
@@ -36,6 +46,8 @@ func (c *Conn) Ping(ctx context.Context) error {
 // and is called in place of any ColumnConverter. CheckNamedValue must do type
 // validation and conversion as appropriate for the driver.
 func (c *Conn) CheckNamedValue(val *driver.NamedValue) error {
+	c.logOp("CheckNamedValue")
+
 	t, ok := val.Value.(time.Time)
 	if ok {
 		val.Value = t.Format(hive.TimestampFormat)
@@ -51,6 +63,8 @@ func (c *Conn) Prepare(query string) (driver.Stmt, error) {
 
 // PrepareContext returns prepared statement
 func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	c.logOp("PrepareContext")
+
 	return &Stmt{
 		conn: c,
 		stmt: template(query),
@@ -59,6 +73,8 @@ func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, e
 
 // QueryContext executes a query that may return rows
 func (c *Conn) QueryContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Rows, error) {
+	c.logOp("QueryContext")
+
 	session, err := c.OpenSession(ctx)
 	if err != nil {
 		return nil, hive.WithStack(err)
@@ -74,6 +90,8 @@ func (c *Conn) QueryContext(ctx context.Context, q string, args []driver.NamedVa
 
 // ExecContext executes a query that doesn't return rows
 func (c *Conn) ExecContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Result, error) {
+	c.logOp("ExecContext")
+
 	session, err := c.OpenSession(ctx)
 	if err != nil {
 		return nil, hive.WithStack(err)
@@ -94,6 +112,8 @@ func (c *Conn) Begin() (driver.Tx, error) {
 
 // OpenSession ensure opened session
 func (c *Conn) OpenSession(ctx context.Context) (*hive.Session, error) {
+	c.logOp("OpenSession")
+
 	if c.session == nil {
 		session, err := c.client.OpenSession(ctx)
 		if err != nil {
@@ -107,6 +127,8 @@ func (c *Conn) OpenSession(ctx context.Context) (*hive.Session, error) {
 
 // ResetSession closes hive session
 func (c *Conn) ResetSession(ctx context.Context) error {
+	c.logOp("ResetSession")
+
 	if c.session != nil {
 		if err := c.session.Close(ctx); err != nil {
 			return hive.WithStack(err)
@@ -118,6 +140,7 @@ func (c *Conn) ResetSession(ctx context.Context) error {
 
 // Close connection
 func (c *Conn) Close() error {
+	c.logOp("Close")
 	c.log.Printf("close connection")
 	return c.t.Close()
 }

--- a/connection.go
+++ b/connection.go
@@ -22,11 +22,11 @@ type Conn struct {
 func (c *Conn) Ping(ctx context.Context) error {
 	session, err := c.OpenSession(ctx)
 	if err != nil {
-		return err
+		return hive.WithStack(err)
 	}
 
 	if err := session.Ping(ctx); err != nil {
-		return err
+		return hive.WithStack(err)
 	}
 
 	return nil
@@ -61,13 +61,13 @@ func (c *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, e
 func (c *Conn) QueryContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Rows, error) {
 	session, err := c.OpenSession(ctx)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	tmpl := template(q)
 	stmt, err := statement(tmpl, args)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 	return query(ctx, session, stmt)
 }
@@ -76,13 +76,13 @@ func (c *Conn) QueryContext(ctx context.Context, q string, args []driver.NamedVa
 func (c *Conn) ExecContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Result, error) {
 	session, err := c.OpenSession(ctx)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	tmpl := template(q)
 	stmt, err := statement(tmpl, args)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 	return exec(ctx, session, stmt)
 }
@@ -109,7 +109,7 @@ func (c *Conn) OpenSession(ctx context.Context) (*hive.Session, error) {
 func (c *Conn) ResetSession(ctx context.Context) error {
 	if c.session != nil {
 		if err := c.session.Close(ctx); err != nil {
-			return err
+			return hive.WithStack(err)
 		}
 		c.session = nil
 	}

--- a/databricks.go
+++ b/databricks.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"io"
 	"io/ioutil"
+	"time"
 )
 
 func init() {
@@ -19,6 +20,7 @@ type Options struct {
 	MaxRows        int64
 	Timeout        int
 	UserAgentEntry string
+	Loc            *time.Location
 
 	LogOut io.Writer
 }
@@ -28,6 +30,16 @@ const (
 	DriverName    = "godatabrickssqlconnector"
 	DriverVersion = "0.9.0"
 )
+
+func (o *Options) Equal(o2 *Options) bool {
+	return o.Host == o2.Host &&
+		o.Port == o2.Port &&
+		o.Token == o2.Token &&
+		o.HTTPPath == o2.HTTPPath &&
+		o.MaxRows == o2.MaxRows &&
+		o.Timeout == o2.Timeout &&
+		o.Loc.String() == o2.Loc.String()
+}
 
 var (
 	// DefaultOptions for the driver

--- a/driver.go
+++ b/driver.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -115,6 +117,16 @@ func parseURI(uri string) (*Options, error) {
 		}
 	}
 
+	if logOut, ok := query["logOut"]; ok {
+		if logOut[0] == "stdout" {
+			opts.LogOut = os.Stdout
+		} else if logOut[0] == "stderr" {
+			opts.LogOut = os.Stderr
+		} else {
+			return nil, fmt.Errorf("invalid logOut %s", logOut[0])
+		}
+	}
+
 	return &opts, nil
 }
 
@@ -187,5 +199,8 @@ func connect(opts *Options) (*Conn, error) {
 
 	client := hive.NewClient(tclient, logger, &hive.Options{MaxRows: opts.MaxRows, Loc: opts.Loc})
 
-	return &Conn{client: client, t: transport, log: logger}, nil
+	connId := rand.Uint64()
+
+	logger.Printf("connect: connId=%d host=%s port=%s httpPath=%s", connId, opts.Host, opts.Port, opts.HTTPPath)
+	return &Conn{client: client, t: transport, log: logger, id: connId}, nil
 }

--- a/driver.go
+++ b/driver.go
@@ -29,7 +29,7 @@ type Driver struct{}
 func (d *Driver) Open(uri string) (driver.Conn, error) {
 	opts, err := parseURI(uri)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	// (eric) Don't log opts because it contains sensitive information.
@@ -37,7 +37,7 @@ func (d *Driver) Open(uri string) (driver.Conn, error) {
 
 	conn, err := connect(opts)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 	return conn, nil
 }
@@ -45,7 +45,7 @@ func (d *Driver) Open(uri string) (driver.Conn, error) {
 func parseURI(uri string) (*Options, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	if u.Scheme != "databricks" {
@@ -69,7 +69,7 @@ func parseURI(uri string) (*Options, error) {
 
 	host, port, err := net.SplitHostPort(u.Host)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	opts.Host = host
@@ -123,7 +123,7 @@ func (d *Driver) OpenConnector(name string) (driver.Connector, error) {
 
 	opts, err := parseURI(name)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	return &connector{opts: opts}, nil
@@ -161,14 +161,14 @@ func connect(opts *Options) (*Conn, error) {
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	httpOptions := thrift.THttpClientOptions{Client: httpClient}
 	endpointUrl := fmt.Sprintf("https://%s:%s@%s:%s"+opts.HTTPPath, "token", url.QueryEscape(opts.Token), opts.Host, opts.Port)
 	transport, err = thrift.NewTHttpClientTransportFactoryWithOptions(endpointUrl, httpOptions).GetTransport(socket)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	httpTransport, ok := transport.(*thrift.THttpClient)

--- a/driver_test.go
+++ b/driver_test.go
@@ -3,24 +3,30 @@ package dbsql
 import (
 	"io/ioutil"
 	"testing"
+	"time"
 )
 
 func TestParseURI(t *testing.T) {
+	americaLosAngelesTz, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		in  string
 		out Options
 	}{
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 10000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 10000, Timeout: 0, LogOut: ioutil.Discard, Loc: time.UTC},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 10000, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 10000, LogOut: ioutil.Discard, Loc: time.UTC},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123&maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", Timeout: 123, MaxRows: 1000, LogOut: ioutil.Discard, Loc: time.UTC},
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?timeout=123&maxRows=1000&userAgentEntry=client-provided-info",
@@ -28,11 +34,15 @@ func TestParseURI(t *testing.T) {
 		},
 		{
 			"databricks://token:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard, Loc: time.UTC},
 		},
 		{
 			"databricks://:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000",
-			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard},
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard, Loc: time.UTC},
+		},
+		{
+			"databricks://:supersecret@example.cloud.databricks.com/sql/1.0/endpoints/12346a5b5b0e123a?maxRows=1000&tz=America%2FLos_Angeles",
+			Options{Host: "example.cloud.databricks.com", Port: "443", Token: "supersecret", HTTPPath: "/sql/1.0/endpoints/12346a5b5b0e123a", MaxRows: 1000, Timeout: 0, LogOut: ioutil.Discard, Loc: americaLosAngelesTz},
 		},
 	}
 
@@ -43,7 +53,7 @@ func TestParseURI(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			if *opts != tt.out {
+			if !opts.Equal(&tt.out) {
 				t.Errorf("got: %v, want: %v", opts, tt.out)
 			}
 		})

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/databricks/databricks-sql-go
 
 go 1.18
 
-require github.com/apache/thrift v0.12.0
+require (
+	github.com/apache/thrift v0.12.0
+	github.com/pkg/errors v0.9.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/apache/thrift v0.12.0 h1:pODnxUFNcjP9UTLZGTdeh+j16A8lJbRvD3rOtrk/7bs=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/hive/client.go
+++ b/hive/client.go
@@ -3,6 +3,7 @@ package hive
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/databricks/databricks-sql-go/cli_service"
@@ -18,6 +19,7 @@ type Client struct {
 // Options for Hive Client
 type Options struct {
 	MaxRows int64
+	Loc     *time.Location
 }
 
 // NewClient creates Hive Client

--- a/hive/client.go
+++ b/hive/client.go
@@ -42,10 +42,10 @@ func (c *Client) OpenSession(ctx context.Context) (*Session, error) {
 
 	resp, err := c.client.OpenSession(ctx, &req)
 	if err != nil {
-		return nil, err
+		return nil, WithStack(err)
 	}
 	if err := checkStatus(resp); err != nil {
-		return nil, err
+		return nil, WithStack(err)
 	}
 
 	c.log.Printf("open session: %s", guid(resp.SessionHandle.GetSessionId().GUID))

--- a/hive/errors.go
+++ b/hive/errors.go
@@ -1,0 +1,19 @@
+package hive
+
+import (
+	"github.com/pkg/errors"
+)
+
+type errorStackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+//adds a stack trace if not already present
+func WithStack(err error) error {
+	if _, ok := err.(errorStackTracer); ok {
+		return err
+	}
+	// newError := errors.WithStack(err)
+	// fmt.Printf("%+v\n", newError)
+	return errors.WithStack(err)
+}

--- a/hive/hive.go
+++ b/hive/hive.go
@@ -11,6 +11,7 @@ import (
 const (
 	// TimestampFormat is JDBC compliant timestamp format
 	TimestampFormat = "2006-01-02 15:04:05.999999999"
+	DateFormat      = "2006-01-02"
 )
 
 // RPCResponse respresents thrift rpc response

--- a/hive/hive.go
+++ b/hive/hive.go
@@ -24,10 +24,10 @@ func checkStatus(resp interface{}) error {
 	if ok {
 		status := rpcresp.GetStatus()
 		if status.StatusCode == cli_service.TStatusCode_ERROR_STATUS {
-			return errors.New(status.GetErrorMessage())
+			return WithStack(errors.New(status.GetErrorMessage()))
 		}
 		if status.StatusCode == cli_service.TStatusCode_INVALID_HANDLE_STATUS {
-			return errors.New("thrift: invalid handle")
+			return WithStack(errors.New("thrift: invalid handle"))
 		}
 
 		// SUCCESS, SUCCESS_WITH_INFO, STILL_EXECUTING are ok
@@ -35,7 +35,7 @@ func checkStatus(resp interface{}) error {
 	}
 
 	log.Printf("response: %v", resp)
-	return errors.New("thrift: invalid response")
+	return WithStack(errors.New("thrift: invalid response"))
 }
 
 func guid(b []byte) string {

--- a/hive/operation.go
+++ b/hive/operation.go
@@ -119,8 +119,8 @@ func (op *Operation) Close(ctx context.Context) error {
 	return nil
 }
 
-// Cancel cancels operation
-func (op *Operation) Cancel(ctx context.Context) error {
+// private method to cancel operation
+func (op *Operation) cancel(ctx context.Context) error {
 	req := cli_service.TCancelOperationReq{
 		OperationHandle: op.h,
 	}

--- a/hive/operation.go
+++ b/hive/operation.go
@@ -74,6 +74,7 @@ func (op *Operation) FetchResults(ctx context.Context, schema *TableSchema) (*Re
 		result:  resp.Results,
 		more:    resp.GetHasMoreRows(),
 		schema:  schema,
+		loc:     op.hive.opts.Loc,
 		fetchfn: func() (*cli_service.TFetchResultsResp, error) { return fetch(ctx, op, schema) },
 	}
 

--- a/hive/operation.go
+++ b/hive/operation.go
@@ -32,10 +32,10 @@ func (op *Operation) GetResultSetMetadata(ctx context.Context) (*TableSchema, er
 
 	resp, err := op.hive.client.GetResultSetMetadata(ctx, &req)
 	if err != nil {
-		return nil, err
+		return nil, WithStack(err)
 	}
 	if err := checkStatus(resp); err != nil {
-		return nil, err
+		return nil, WithStack(err)
 	}
 
 	schema := new(TableSchema)
@@ -65,7 +65,7 @@ func (op *Operation) FetchResults(ctx context.Context, schema *TableSchema) (*Re
 
 	resp, err := fetch(ctx, op, schema)
 	if err != nil {
-		return nil, err
+		return nil, WithStack(err)
 	}
 
 	rs := ResultSet{
@@ -93,10 +93,10 @@ func fetch(ctx context.Context, op *Operation, schema *TableSchema) (*cli_servic
 
 	resp, err := op.hive.client.FetchResults(ctx, &req)
 	if err != nil {
-		return nil, err
+		return nil, WithStack(err)
 	}
 	if err := checkStatus(resp); err != nil {
-		return nil, err
+		return nil, WithStack(err)
 	}
 
 	op.hive.log.Printf("results: %v", resp.Results)
@@ -110,10 +110,10 @@ func (op *Operation) Close(ctx context.Context) error {
 	}
 	resp, err := op.hive.client.CloseOperation(ctx, &req)
 	if err != nil {
-		return err
+		return WithStack(err)
 	}
 	if err := checkStatus(resp); err != nil {
-		return err
+		return WithStack(err)
 	}
 
 	op.hive.log.Printf("close operation: %v", guid(op.h.OperationId.GUID))

--- a/hive/operation.go
+++ b/hive/operation.go
@@ -52,9 +52,9 @@ func (op *Operation) GetResultSetMetadata(ctx context.Context) (*TableSchema, er
 			})
 		}
 
-		for _, col := range schema.Columns {
-			op.hive.log.Printf("fetch schema: %v", col)
-		}
+		//for _, col := range schema.Columns {
+		//	op.hive.log.Printf("fetch schema: %v", col)
+		//}
 	}
 
 	return schema, nil
@@ -99,7 +99,7 @@ func fetch(ctx context.Context, op *Operation, schema *TableSchema) (*cli_servic
 		return nil, WithStack(err)
 	}
 
-	op.hive.log.Printf("results: %v", resp.Results)
+	//op.hive.log.Printf("results: %v", resp.Results)
 	return resp, nil
 }
 

--- a/hive/operation.go
+++ b/hive/operation.go
@@ -118,3 +118,21 @@ func (op *Operation) Close(ctx context.Context) error {
 	op.hive.log.Printf("close operation: %v", guid(op.h.OperationId.GUID))
 	return nil
 }
+
+// Cancel cancels operation
+func (op *Operation) Cancel(ctx context.Context) error {
+	req := cli_service.TCancelOperationReq{
+		OperationHandle: op.h,
+	}
+
+	resp, err := op.hive.client.CancelOperation(ctx, &req)
+	if err != nil {
+		return err
+	}
+	if err := checkStatus(resp); err != nil {
+		return err
+	}
+
+	op.hive.log.Printf("cancel operation: %v", guid(op.h.OperationId.GUID))
+	return nil
+}

--- a/hive/result_set.go
+++ b/hive/result_set.go
@@ -77,11 +77,16 @@ func value(col *cli_service.TColumn, cd *ColDesc, i int, loc *time.Location) (in
 	}
 
 	switch cd.DatabaseTypeName {
-	case "STRING", "CHAR", "VARCHAR":
+	case "STRING", "CHAR", "VARCHAR", "MAP":
 		if isNull(col.StringVal.Nulls, i) {
 			return nil, nil
 		}
 		return col.StringVal.Values[i], nil
+	case "BINARY":
+		if isNull(col.BinaryVal.Nulls, i) {
+			return nil, nil
+		}
+		return col.BinaryVal.Values[i], nil
 	case "TINYINT":
 		if isNull(col.ByteVal.Nulls, i) {
 			return nil, nil
@@ -121,6 +126,16 @@ func value(col *cli_service.TColumn, cd *ColDesc, i int, loc *time.Location) (in
 			return nil, err
 		}
 		return t, nil
+	case "DATE":
+		if isNull(col.StringVal.Nulls, i) {
+			return nil, nil
+		}
+		t, err := time.ParseInLocation(DateFormat, col.StringVal.Values[i], loc)
+		if err != nil {
+			return nil, err
+		}
+		return t, nil
+
 	default:
 		if isNull(col.StringVal.Nulls, i) {
 			return nil, nil

--- a/hive/result_set.go
+++ b/hive/result_set.go
@@ -14,6 +14,7 @@ type ResultSet struct {
 	length  int
 	fetchfn func() (*cli_service.TFetchResultsResp, error)
 	schema  *TableSchema
+	loc     *time.Location
 
 	operation *Operation
 	result    *cli_service.TRowSet
@@ -49,8 +50,7 @@ func (rs *ResultSet) Next(dest []driver.Value) error {
 	}
 
 	for i := range dest {
-		val, err := value(rs.result.Columns[i], rs.schema.Columns[i], rs.idx)
-
+		val, err := value(rs.result.Columns[i], rs.schema.Columns[i], rs.idx, rs.loc)
 		if err != nil {
 			return err
 		}
@@ -71,7 +71,11 @@ func isNull(nulls []byte, position int) bool {
 	return false
 }
 
-func value(col *cli_service.TColumn, cd *ColDesc, i int) (interface{}, error) {
+func value(col *cli_service.TColumn, cd *ColDesc, i int, loc *time.Location) (interface{}, error) {
+	if loc == nil {
+		loc = time.UTC
+	}
+
 	switch cd.DatabaseTypeName {
 	case "STRING", "CHAR", "VARCHAR":
 		if isNull(col.StringVal.Nulls, i) {
@@ -112,7 +116,7 @@ func value(col *cli_service.TColumn, cd *ColDesc, i int) (interface{}, error) {
 		if isNull(col.StringVal.Nulls, i) {
 			return nil, nil
 		}
-		t, err := time.Parse(TimestampFormat, col.StringVal.Values[i])
+		t, err := time.ParseInLocation(TimestampFormat, col.StringVal.Values[i], loc)
 		if err != nil {
 			return nil, err
 		}

--- a/hive/result_set.go
+++ b/hive/result_set.go
@@ -32,7 +32,7 @@ func (rs *ResultSet) Next(dest []driver.Value) error {
 		resp, err := rs.fetchfn()
 
 		if err != nil {
-			return err
+			return WithStack(err)
 		}
 
 		// Replace previous page of results with new page of results
@@ -52,7 +52,7 @@ func (rs *ResultSet) Next(dest []driver.Value) error {
 	for i := range dest {
 		val, err := value(rs.result.Columns[i], rs.schema.Columns[i], rs.idx, rs.loc)
 		if err != nil {
-			return err
+			return WithStack(err)
 		}
 
 		dest[i] = val
@@ -123,7 +123,7 @@ func value(col *cli_service.TColumn, cd *ColDesc, i int, loc *time.Location) (in
 		}
 		t, err := time.ParseInLocation(TimestampFormat, col.StringVal.Values[i], loc)
 		if err != nil {
-			return nil, err
+			return nil, WithStack(err)
 		}
 		return t, nil
 	case "DATE":

--- a/hive/session.go
+++ b/hive/session.go
@@ -21,10 +21,10 @@ func (s *Session) Ping(ctx context.Context) error {
 
 	resp, err := s.hive.client.GetInfo(ctx, &req)
 	if err != nil {
-		return err
+		return WithStack(err)
 	}
 	if err := checkStatus(resp); err != nil {
-		return err
+		return WithStack(err)
 	}
 
 	s.hive.log.Printf("ping. server name: %s", resp.InfoValue.GetStringValue())
@@ -40,10 +40,10 @@ func (s *Session) ExecuteStatement(ctx context.Context, stmt string) (*Operation
 	resp, err := s.hive.client.ExecuteStatement(ctx, &req)
 
 	if err != nil {
-		return nil, err
+		return nil, WithStack(err)
 	}
 	if err := checkStatus(resp); err != nil {
-		return nil, err
+		return nil, WithStack(err)
 	}
 	s.hive.log.Printf("execute operation: %s", guid(resp.OperationHandle.OperationId.GUID))
 	s.hive.log.Printf("operation. has resultset: %v", resp.OperationHandle.GetHasResultSet())
@@ -59,10 +59,10 @@ func (s *Session) Close(ctx context.Context) error {
 	}
 	resp, err := s.hive.client.CloseSession(ctx, &req)
 	if err != nil {
-		return err
+		return WithStack(err)
 	}
 	if err := checkStatus(resp); err != nil {
-		return err
+		return WithStack(err)
 	}
 	return nil
 }

--- a/statement.go
+++ b/statement.go
@@ -62,11 +62,11 @@ func (s *Stmt) Query(args []driver.Value) (driver.Rows, error) {
 func (s *Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
 	session, err := s.conn.OpenSession(ctx)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 	stmt, err := statement(s.stmt, args)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 	return query(ctx, session, stmt)
 }
@@ -75,11 +75,11 @@ func (s *Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driv
 func (s *Stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
 	session, err := s.conn.OpenSession(ctx)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 	stmt, err := statement(s.stmt, args)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 	return exec(ctx, session, stmt)
 }
@@ -119,17 +119,17 @@ func statement(tmpl string, args []driver.NamedValue) (string, error) {
 func query(ctx context.Context, session *hive.Session, stmt string) (driver.Rows, error) {
 	operation, err := session.ExecuteStatement(ctx, stmt)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	schema, err := operation.GetResultSetMetadata(ctx)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	rs, err := operation.FetchResults(ctx, schema)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	return &Rows{
@@ -142,11 +142,11 @@ func query(ctx context.Context, session *hive.Session, stmt string) (driver.Rows
 func exec(ctx context.Context, session *hive.Session, stmt string) (driver.Result, error) {
 	operation, err := session.ExecuteStatement(ctx, stmt)
 	if err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	if err := operation.Close(ctx); err != nil {
-		return nil, err
+		return nil, hive.WithStack(err)
 	}
 
 	return driver.ResultNoRows, nil


### PR DESCRIPTION
This PR rebases our fork of `databricks-sql-go` with the latest upstream, explicitly leaving out https://github.com/databricks/databricks-sql-go/pull/25 due to an incompatibility between the new dependency version it introduces (Arrow v0.17) and our client code. We can bring in the latest changes once we've upgraded our client code to be compatible with the latest dependency versions.