### PR TITLE
Don't ignore error in InitThriftClient

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -212,6 +212,10 @@ func InitThriftClient(cfg *config.Config) (*ThriftServiceClient, error) {
 			Timeout:   cfg.ClientTimeout,
 		}
 		tTrans, err = thrift.NewTHttpClientWithOptions(endpoint, thrift.THttpClientOptions{Client: httpclient})
+		if err != nil {
+			return nil, err
+		}
+
 		httpTransport := tTrans.(*thrift.THttpClient)
 		userAgent := fmt.Sprintf("%s/%s", cfg.DriverName, cfg.DriverVersion)
 		if cfg.UserAgentEntry != "" {


### PR DESCRIPTION
`thrift.NewTHttpClientWithOptions` may return an error, in which case `tTrans` is `nil`, which causes the next line to panic with the message `interface conversion: thrift.TTransport is nil, not *thrift.THttpClient` on the next line.